### PR TITLE
Migrate to self-hosted CircleCI runners with BuildKit orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,7 @@
 version: 2.1
+
 orbs:
-  aws-ecr: circleci/aws-ecr@9.0.2
-  aws-cli: circleci/aws-cli@4.1.1
-
-
-parameters:
-  oidc_role:
-    type: string
-    default: 'arn:aws:iam::193567999519:role/aws-es-proxy-oidc'
+  build-tools: onemedical/build-tools@1.5.0
 
 commands:
 
@@ -19,28 +13,24 @@ commands:
           command: |
             echo 'export VERSION_TAG=branch-$(echo $CIRCLE_BRANCH | tr / -)' >> $BASH_ENV
             echo 'export RELEASE_TAG=$([[ "$CIRCLE_BRANCH" == "master" ]] && echo "latest,")' >> $BASH_ENV
+            echo 'export CIRCLE_TAG=${CIRCLE_TAG:-}' >> $BASH_ENV
 
 jobs:
   release:
-    machine:
-      docker_layer_caching: true
+    executor:
+      name: build-tools/default
+      resource_class: onemedical/eks-buildkit-small
     steps:
       - checkout
       - create_image_tag
-      - aws-ecr/build_and_push_image:
-          account_id: '${AWS_ECR_REGISTRY_ID}'
-          auth:
-            - aws-cli/setup:
-                role_arn: '<<pipeline.parameters.oidc_role>>'
-                role_session_name: circleci
-          dockerfile: Dockerfile
+      - build-tools/setup_buildkit
+      - build-tools/build_and_push_image:
           repo: onemedical/aws-es-proxy
-          region: '${AWS_REGION}'
+          account_id: "193567999519"
           # comma added by RELEASE_TAG if set. Kludge to get this to work is simpler than most alternatives.
           tag: '${VERSION_TAG},${VERSION_TAG}-${CIRCLE_SHA1},${RELEASE_TAG}${CIRCLE_TAG}'
 
 workflows:
-  version: 2
   everything:
     jobs:
       - release:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-FROM golang:1.23-alpine
+# golang:1.23-alpine
+FROM 329601960842.dkr.ecr.us-east-1.amazonaws.com/docker/library/golang@sha256:383395b794dffa5b53012a212365d40c8e37109a626ca30d6151c8348d380b5f
 
 WORKDIR /go/src/github.com/abutaha/aws-es-proxy
 COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o aws-es-proxy
 
-FROM alpine:3.20
+# alpine:3.20
+FROM 329601960842.dkr.ecr.us-east-1.amazonaws.com/docker/library/alpine@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
 LABEL name="aws-es-proxy" \
       version="latest"
 


### PR DESCRIPTION
Replace machine executor + aws-ecr orb with build-tools orb on EKS self-hosted runners. IRSA handles ECR auth (no OIDC). Dockerfile FROM lines routed through CI-account pull-through cache with SHA pins.

Taskei: [HSTPRO-147](https://taskei.amazon.dev/tasks/HSTPRO-147)

